### PR TITLE
Improve bluetooth timeout and connection abort issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ services:
     build:
       context: https://github.com/aso824/yeehack.git
       dockerfile: Dockerfile
+    network_mode: host # this may not be necessary for all setups but works best with hosts bluetooth
     ports:
       - "8888:8080"
     volumes:

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Default port is 8080, add `--port [PORT]` to change.
 
 Fetch info about lock (currently only battery state):
 
-    curl -XPOST http://localhost:8080/info -d '{"sn": "..."}'
+    curl -XPOST http://localhost:8080/info -d '{"sn": "...", "timeout": "5"}'
     
 Lock or unlock:
 
-    curl -XPOST http://localhost:8080/do -d '{"sn": "...", "sign_key": "...", "action": "unlock"}' 
+    curl -XPOST http://localhost:8080/do -d '{"sn": "...", "sign_key": "...", "timeout": "5", "action": "unlock"}' 
 
 Supported actions: `lock`, `unlock`, `temp_unlock` (unlock and lock after a while)
 
@@ -113,12 +113,12 @@ rest_command:
     url: http://127.0.0.1:8888/do
     method: POST
     content_type:  'application/json; charset=utf-8'
-    payload: '{"sn": "YYYYY", "sign_key": "XXXXX", "action": "lock"}'
+    payload: '{"sn": "YYYYY", "sign_key": "XXXXX", "timeout": "5", "action": "lock"}'
   yeelock_unlock:
     url: http://127.0.0.1:8888/do
     method: POST
     content_type:  'application/json; charset=utf-8'
-    payload: '{"sn": "YYYYY", "sign_key": "XXXXX", "action": "unlock"}'
+    payload: '{"sn": "YYYYY", "sign_key": "XXXXX", "timeout": "5", "action": "unlock"}'
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ rest_command:
     method: POST
     content_type:  'application/json; charset=utf-8'
     payload: '{"sn": "YYYYY", "sign_key": "XXXXX", "timeout": "5", "action": "unlock"}'
+  yeelock_temp_unlock:
+    url: http://127.0.0.1:8888/do
+    method: POST
+    content_type:  'application/json; charset=utf-8'
+    payload: '{"sn": "YYYYY", "sign_key": "XXXXX", "timeout": "5", "action": "temp_unlock"}'
 ```
 
 ## Development

--- a/lock.py
+++ b/lock.py
@@ -15,14 +15,15 @@ from packet import ActionPacket, UnlockMode
 
 
 class Lock:
-    def __init__(self, sn: str, sign_key: bytearray):
+    def __init__(self, sn: str, sign_key: bytearray, timeout: int = 5.0):
         self.sn: str = sn
         self.sign_key: bytearray = sign_key
+        self.timeout: int = timeout
         self.device = None
 
     @staticmethod
-    async def create(sn: str, sign_key: bytearray) -> Lock:
-        self = Lock(sn, sign_key)
+    async def create(sn: str, sign_key: bytearray, timeout: int) -> Lock:
+        self = Lock(sn, sign_key, timeout)
 
         await self.__find_mac()
 
@@ -41,7 +42,7 @@ class Lock:
 
     async def get_battery(self) -> int:
         try:
-            async with BleakClient(self.device, timeout=5.0) as client:
+            async with BleakClient(self.device, timeout=self.timeout) as client:
                 connection = Connection(client, self.sign_key)
                 return await connection.battery_level()
         except (asyncio.exceptions.TimeoutError, bleak.exc.BleakDBusError) as e:
@@ -59,7 +60,7 @@ class Lock:
         await self.__do_action(UnlockMode.TEMP_UNLOCK)
 
     async def __do_action(self, mode: UnlockMode) -> None:
-        async with BleakClient(self.device, timeout=2.0) as client:
+        async with BleakClient(self.device, timeout=self.timeout) as client:
             connection = Connection(client, self.sign_key)
 
             await connection.init()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ aiohttp==3.8.3
 aiosignal==1.2.0
 async-timeout==4.0.2
 attrs==22.1.0
-bleak==0.18.1
+bleak==0.20.0
 certifi==2022.9.24
 charset-normalizer==2.1.1
-dbus-fast==1.29.1
+dbus-fast==1.84.2
 frozenlist==1.3.1
 idna==3.4
 multidict==6.0.2

--- a/server.py
+++ b/server.py
@@ -30,11 +30,12 @@ class Server:
         try:
             data = await request.json()
             sn = data['sn']
+            timeout = int(data['timeout'])
         except (json.decoder.JSONDecodeError, AttributeError, KeyError):
             return web.json_response({'error': 'Invalid input'}, status=400)
 
         try:
-            lock = await Lock.create(sn, bytearray())
+            lock = await Lock.create(sn, bytearray(), timeout)
             level = await lock.get_battery()
         except errors.DeviceNotFoundError:
             return web.json_response({'error': 'Device not found'}, status=400)
@@ -48,11 +49,12 @@ class Server:
             action = data['action']
             sn = data['sn']
             sign_key = data['sign_key']
+            timeout = int(data['timeout'])
         except (json.decoder.JSONDecodeError, AttributeError, KeyError):
             return web.json_response({'error': 'Invalid input'}, status=400)
 
         try:
-            lock = await Lock.create(sn, bytearray.fromhex(sign_key))
+            lock = await Lock.create(sn, bytearray.fromhex(sign_key), timeout)
         except ValueError:
             return web.json_response({'error': 'Sign key is not a hexadecimal string'}, status=400)
         except errors.DeviceNotFoundError:

--- a/yeehack.py
+++ b/yeehack.py
@@ -23,6 +23,10 @@ subparsers = parser.add_subparsers(help='Available commands:', dest='command', m
 
 parser_battery = subparsers.add_parser('battery', help='Get battery level')
 parser_battery.add_argument('sn', help='Serial number (string) of your Yeelock - 8 alphanumeric characters')
+parser_battery.add_argument(
+    '--timeout',
+    help='Bluetooth timeout, useful in noisy environments',
+    type=int, default=5.0, required=False)
 
 parser_do = subparsers.add_parser('do', help='Execute lock/unlock/temp_unlock action')
 parser_do.add_argument(
@@ -32,6 +36,10 @@ parser_do.add_argument(
 )
 parser_do.add_argument('sn', help='Serial number (string) of your Yeelock - 8 alphanumeric characters')
 parser_do.add_argument('sign_key', help='Bluetooth sign key from Yeelock server')
+parser_do.add_argument(
+    '--timeout',
+    help='Bluetooth timeout, useful in noisy environments',
+    type=int, default=5.0, required=False)
 
 parser_battery = subparsers.add_parser('fetch', help='Get info about your locks from Yeelock server')
 
@@ -58,13 +66,13 @@ logging.basicConfig(level=log_levels[args.log_level])
 
 async def main():
     if args.command == 'battery':
-        lock = await Lock.create(args.sn, bytearray())
+        lock = await Lock.create(args.sn, bytearray(), args.timeout)
         level = await lock.get_battery()
 
         print("Battery level: %d%%" % level)
 
     elif args.command == 'do':
-        lock = await Lock.create(args.sn, bytearray.fromhex(args.sign_key))
+        lock = await Lock.create(args.sn, bytearray.fromhex(args.sign_key), args.timeout)
 
         if args.action == 'lock':
             await lock.lock()


### PR DESCRIPTION
[update bleak to 0.20.0 - Adds automatic retry on le-connection-abort-…](https://github.com/aso824/yeehack/commit/de7855d7ac164f30594b0e37756423f00c1bdf9a) This updates Bleak to version 0.20.0 (and bleaks dependency dbus-fast to 1.84.2) which resolves an issue I had with failures due to returned error le-connection-abort-by-local [https://github.com/hbldh/bleak/issues/1220](https://github.com/hbldh/bleak/issues/1220).

[add configurable bluetooth timeout to CLI and webserver](https://github.com/aso824/yeehack/commit/69f162d237c6f15e696a55046e05238a4b291a80) This adds a configurable timeout value in the CLI and webserver to extend BleakClient connection timeout, this is helpful for users who may have particularly noisy environments/slower devices. This change requires the timeout value to be provided in the json body on a POST message. CLI will default to 5 seconds if not specified. README is updated for these changes.

[update readme to add docker compose host mode info](https://github.com/aso824/yeehack/commit/eb5da4675d9683b862e15647eecda51335412df5) Recommend to use docker host mode to prevent issues between host/container contention with bluetooth. Since using host mode in combination with these changes I have had no failures whereas before I had intermittent success.

[update readme to add homeassistant service for temporary unlock](https://github.com/aso824/yeehack/commit/ebed34552f783438327b69bf1d7f22a2173fd4b7) Add example service REST call for temporary unlock in home assistant to readme.